### PR TITLE
SEP-0008: Add the option for the action required URL to support POST

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -135,7 +135,7 @@ status|string|`"action_required"`
 message|string|A human readable string containing information regarding the action required.
 action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
 action_method|string|(Optional) `GET` or `POST`, indicating the type of request that should be made to the `action_url`. If not provided, `GET` is assumed.
-action_fields|string|(Optional) A comma separated list of additional fields defined by [SEP-9](sep-0009.md) that the client may optionally provide to the approval service when sending the request to the `action_url`.
+action_fields|string[]|(Optional) An array of additional fields defined by [SEP-9](sep-0009.md) that the client may optionally provide to the approval service when sending the request to the `action_url`.
 
 #### Rejected Response
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,10 +3,10 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com
+Author: Interstellar.com, Christian Peters (DSTOQ) <@shredding>, Leigh McCulloch <@leighmcculloch>
 Status: Final
 Created: 2018-08-22
-Version 1.0.0
+Version 1.1.0
 ```
 
 ## Simple Summary
@@ -117,7 +117,15 @@ message|string|A human readable string containing information to pass on to the 
 
 #### Action Required Response
 
-An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction if it's synchronous (the default) or wait for a confirmation from the approval service to continue.
+An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+
+If the `action_method` is provided the client uses the type of request indicated when sending a request to the `action_url`. If `action_fields` are to be provided and the fields contain sensitive or personal information the `POST` case is preferred to ensure sensitive information is not transmitted in the URL.
+
+ - In the case that `action_method` is `GET` any fields requested may be passed as query parameters in the `action_url`.
+
+ - In the case that `action_method` is `POST` any fields requested may be passed url-form-encoded or as JSON in the request body, using content types `application/x-www-form-urlencoded` or `application/json`. The server should respond to the `POST` with a HTTP response with status code `301 Moved Permanently` and a `Location` header containing a URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
+
+   The redirect in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser will naturally follow the 301 redirect and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the redirect URL.
 
 Parameters:
 
@@ -126,8 +134,8 @@ Name | Data Type | Description
 status|string|`"action_required"`
 message|string|A human readable string containing information regarding the action required.
 action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
-action_params|string|A comma separated list of additional parameters that the client may optionally provide to the approval service; options are `first_name`, `last_name`, `email` and `public_key`
-action_synchronous|boolean|Indicated wether the action is performed synchronous or asynchronous (it may time for the action to complete)
+action_method|string|(Optional) `GET` or `POST`, indicating the type of request that should be made to the `action_url`. If not provided, `GET` is assumed.
+action_fields|string|(Optional) A comma separated list of additional fields defined by [SEP-9](sep-0009.md) that the client may optionally provide to the approval service when sending the request to the `action_url`.
 
 #### Rejected Response
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -123,7 +123,7 @@ If the `action_method` is provided the client uses the type of request indicated
 
  - In the case that `action_method` is `GET` any fields requested may be passed as query parameters in the `action_url`.
 
- - In the case that `action_method` is `POST` any fields requested may be passed url-form-encoded or as JSON in the request body, using content types `application/x-www-form-urlencoded` or `application/json`. The server should respond to the `POST` with a HTTP response with status code `303 See Other` and a `Location` header containing a URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
+ - In the case that `action_method` is `POST` any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `303 See Other` and a `Location` header containing a URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
 
    The redirect in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser will naturally follow the 303 redirect and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the redirect URL.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -123,9 +123,9 @@ If the `action_method` is provided the client uses the type of request indicated
 
  - In the case that `action_method` is `GET` any fields requested may be passed as query parameters in the `action_url`.
 
- - In the case that `action_method` is `POST` any fields requested may be passed url-form-encoded or as JSON in the request body, using content types `application/x-www-form-urlencoded` or `application/json`. The server should respond to the `POST` with a HTTP response with status code `301 Moved Permanently` and a `Location` header containing a URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
+ - In the case that `action_method` is `POST` any fields requested may be passed url-form-encoded or as JSON in the request body, using content types `application/x-www-form-urlencoded` or `application/json`. The server should respond to the `POST` with a HTTP response with status code `303 See Other` and a `Location` header containing a URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
 
-   The redirect in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser will naturally follow the 301 redirect and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the redirect URL.
+   The redirect in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser will naturally follow the 303 redirect and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the redirect URL.
 
 Parameters:
 


### PR DESCRIPTION
### What

Propose changes to stellar/stellar-protocol#758 to making it possible to pass the action parameters via a POST request.

Also removes some elements of the existing proposal that we agreed to defer.

### Why

The main motivation for offering POST as the method of delivering the request is to keep sensitive information like a user's name, email, or other details, out of the request URL. Any data in a URL may be leaked in a number of ways. Even though request URLs are encrypted using TLS, URLs often get leaked in systems and it is a best practice to keep sensitive data out of them.

This PR is the proposal I made here: https://github.com/stellar/stellar-protocol/pull/758/files#r518319840 and https://github.com/stellar/stellar-protocol/pull/758/files#r518144075.