### PR TITLE
SEP-0008: merge master into PR-758 and update action required to be 200 with next url

### DIFF
--- a/ecosystem/sep-0006.md
+++ b/ecosystem/sep-0006.md
@@ -211,22 +211,23 @@ Mexican peso (MXN) response example:
 ##### Special Cases
 ###### Stellar account does not exist
 
-If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use `create_account` to create the account with at least enough XLM for the minimum reserve and a trust line (2.01 XLM is recommended). The anchor should take some of the asset that is sent in to pay for the XLM. The anchor should not list this minimal funding as a fee because the user still receives the value of the XLM in their account. The anchor should detect if the account has been created before returning deposit information, and adjust the `min_amount` in the response to be at least the amount needed to create the account.
+If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). The can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
-Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the remaining asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the remaining asset tokens to the account in Stellar to complete the deposit.
+Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account in Stellar to complete the deposit.
 
-If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error. The response body should be a JSON object containing an `error` field that explains why the request failed.
+If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the [deposit](#deposit) response. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
 ###### Stellar account doesn't trust asset
 
-The deposit flow can only be fulfilled if the Stellar `Account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `Account` has a trust line for the given asset. If it doesn't:
+The deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
 
-1. `Wallet` checks if `Account` has enough XLM to create a trust line. If it does, skip to step `4`.
-2. If `Account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `Account`, waiting for it to have enough XLM for a trust line.
-3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` then starts listening for trust line creations for that `Account`.
-4. `Wallet` detects the arrival of XLM in the `Account`, and establishes a trust line.
-5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
-6. `Anchor` proceeds with the deposit flow.
+1. `Wallet` checks if `account` has enough XLM to create a trust line. If it does, skip to step `4`.
+2. If `account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `account`, waiting for it to have enough XLM for a trust line.
+3. When asked for a deposit, `Anchor` detects if `account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` may charge a service fee to cover the cost of the XLM, but this must be communicated to the user.
+4. `Anchor` then starts listening for trust line creations for that `account`.
+5. `Wallet` detects the arrival of XLM in the `account`, and establishes a trust line.
+6. `Anchor` detects the trust line creation in the `account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
+7. `Anchor` proceeds with the deposit flow.
 
 ## Withdraw
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-07
-Version 1.0.1
+Updated: 2021-01-08
+Version 1.1.1
 ```
 
 ## Simple Summary
@@ -79,9 +79,10 @@ The specification of an approval server is defined as follows:
 
 ### Content Type
 
-Approval server accepts requests in the `Content-Type`:
+Approval server accepts requests in the following `Content-Type`s:
 
 - `application/x-www-form-urlencoded`
+- `application/json`
 
 Approval server responds with the `Content-Type`:
 
@@ -96,6 +97,14 @@ This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 Name | Type | Description
 -----|------|------------
 `tx` | string | A base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
+
+###### Example (JSON)
+
+```json
+{
+  "tx": "AAAAAHAHhQtYBh5F2zA6..."
+}
+```
 
 ###### Example (Form)
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -218,14 +218,6 @@ This reponse means that the user must complete an action before this transaction
 
 An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
 
-If the `action_method` is provided the client uses the type of request indicated when sending a request to the `action_url`. If `action_fields` are to be provided and the fields contain sensitive or personal information the `POST` case is preferred to ensure sensitive information is not transmitted in the URL.
-
- - In the case that `action_method` is `GET` any fields requested may be passed as query parameters in the `action_url`.
-
- - In the case that `action_method` is `POST` any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `303 See Other` and a `Location` header containing a URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
-
-   The redirect in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser will naturally follow the 303 redirect and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the redirect URL.
-
 Parameters:
 
 Name | Type | Description
@@ -247,6 +239,29 @@ Name | Type | Description
   "action_fields": ["email_address", "mobile_number"]
 }
 ```
+
+###### Action URL
+If the `action_method` is provided the client uses the type of request indicated when sending a request to the `action_url`. If `action_fields` are to be provided and the fields contain sensitive or personal information the `POST` case is preferred to ensure sensitive information is not transmitted in the URL.
+
+- In the case that `action_method` is `GET` any fields requested may be passed as query parameters in the `action_url`.
+
+- In the case that `action_method` is `POST` any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json` and a body containing the next URL that the user should be taken to.
+
+   The next URL in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser can redirect the user to the next URL and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the next URL.
+
+   Parameters:
+
+   Name | Type | Description
+   -----|------|------------
+   `next_url` | string | A URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
+
+   Example:
+
+   ```json
+   {
+     "next_url": "https://..."
+   }
+   ```
 
 ##### Rejected
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -6,8 +6,8 @@ Title: Regulated Assets
 Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2021-01-08
-Version 1.1.1
+Updated: 2021-01-11
+Version 1.2.1
 ```
 
 ## Simple Summary
@@ -69,6 +69,30 @@ issuer="GD5T6IPRNCKFOHQWT264YPKOZAWUMMZOLZBJ6BNQMUGPWGRLBK3U7ZNP"
 regulated=true
 approval_server="https://goat.io/tx_approve"
 approval_criteria="The goat approval server will ensure that transactions are compliant with NFO regulation"
+```
+
+## Transaction Composition
+
+A transaction that an approval server will approve consists of operations that authorize the clients' accounts, transact the regulated asset, and deauthorize the clients' accounts. If a transaction is built this way, there will be no point where the clients' accounts have open, authorized trustlines to run unapproved operations because of transaction atomocity. A transaction as described above can be built by wallets preemptively or by approval servers in order to make it compliant when the [revised](#revised) status is applicable.
+
+Depending on whether issuers want to allow the clients' accounts to maintain offers, issuers can leave the accounts in the `AUTHORIZE_TO_MAINTAIN_LIABILITIES_FLAG` state or completely deauthorize the accounts when completing the operation. See [CAP-18] for the fine-grained control of authorization.
+
+An example of the transaction where the issuer allow the client's account to maintain offers:
+
+```
+Operation 1: AllowTrust op where issuer fully authorizes account A, asset X
+Operation 2: Account A manages offer to buy or sell X
+Operation 3: AllowTrust op where issuer sets account A, asset X to AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG state
+```
+
+An example of the transaction where the issuer do not allow the clients' accounts to maintain offers:
+
+```
+Operation 1: AllowTrust op where issuer fully authorizes account A, asset X
+Operation 2: AllowTrust op where issuer fully authorizes account B, asset X
+Operation 3: Payment from A to B
+Operation 4: AllowTrust op where issuer fully deauthorizes account B, asset X
+Operation 5: AllowTrust op where issuer fully deauthorizes account A, asset X
 ```
 
 ## Approval Server
@@ -236,15 +260,12 @@ Name | Type | Description
 
 ### Best practices
 
+- Issuers are encouraged to use the `revised` status to make a transaction complaint when possible, since Wallets may not know how to form a transaction that is compliant with the server's criteria.
 - If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
 - Wallet should inspect revised transactions and alert the user if any of the original operations are changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
 - Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to the issuer's account.
-
-## Account Setup
-
-Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
 
 ## Discussion
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -7,7 +7,7 @@ Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
 Updated: 2021-01-11
-Version 1.2.1
+Version 1.3.1
 ```
 
 ## Simple Summary
@@ -200,7 +200,7 @@ Parameters:
 Name | Type | Description
 -----|------|------------
 `status` | string | `"pending"`
-`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again.
+`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again. Use `0` if the wait time cannot be determined.
 `message` | string | (optional) A human readable string containing information to pass on to the user.
 
 ###### Example

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -3,51 +3,61 @@
 ```
 SEP: 0008
 Title: Regulated Assets
-Author: Interstellar.com
+Author: Interstellar.com, Howard Chen <@howardtw>
 Status: Active
 Created: 2018-08-22
-Updated: 2020-12-09
-Version 1.0.0
+Updated: 2021-01-07
+Version 1.0.1
 ```
 
 ## Simple Summary
 
-Regulated Assets provide ecosystem support for assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
+Regulated Assets are assets that require an issuer’s approval (or a delegated third party’s approval, such as a licensed securities exchange) on a per-transaction basis. It standardizes the identification of such assets as well as defines the protocol for performing compliance checks and requesting issuer approval.
 
-**Target Audience**: Asset issuers, issuance platforms, wallet developers, and exchanges
+## Target Audience
+
+Asset issuers, issuance platforms, wallet developers, and exchanges
 
 ## Motivation
 
-Stellar aims to be an ideal platform for issuing securities. As such, it must provide tools to comply with various regulatory requirements. Regulation often requires asset issuers to monitor and approve every transaction involving the issued asset and to enforce an assortment of constraints. This SEP provides support for these requirements.
+Stellar is an ideal platform for issuing securities. Regulation sometimes requires asset issuers to monitor and approve each transaction involving issued assets and to enforce constraints. This is possible on the Stellar network today, however there exists no standard interface between wallets and issuers to negotiate approval.
 
 ## Overview
 
-Implementing a Regulated Asset consists of these parts:
-- **Stellar.toml**: Issuers will advertise the existence of an Approval Service and the approval criteria via their stellar.toml file.
-- **Approval Server**: HTTP protocol for transaction signing.
-- **Account Setup**: Wallets will have to work with accounts that are controlled or at least partially controlled (via multisig) by asset issuers, rather than the wallet end user.<br/>
-**Note**: this step may not be required once the proposed [protocol change](https://github.com/stellar/stellar-protocol/issues/146) allowing for protocol-level per-transaction approval is implemented.
+Implementing a regulated asset requires these parts:
+- Issuer account with appropriate [authorization flags] set.
+- [SEP-1 stellar.toml] used for discovering [Approval Server].
+- [Approval Server] that validates client transactions according to the service's approval criteria. Validated transactions are signed by the asset's issuing account.
 
 ## Regulated Assets Approval Flow
 
-1. User creates and signs a transaction.
+1. Wallet creates and signs a transaction.
 2. Wallet resolves asset information and detects that it's a regulated asset.
+	1. Wallet can detect whether an asset is a regulated asset by checking the [authorization flags] of the asset issuer's account.
 3. Wallet sends the transaction to the approval server.
-4. Approval server determines whether the transaction is compliant based on the current state of the ledger, known pending transactions, and its compliance ruleset.
+	1. Wallet can find the approval server via [SEP-1 stellar.toml] set up by the issuer.
+4. Approval server determines whether the transaction should be approved.
 5. Wallet handles approval response:
-    1. *Success?* Transaction has been approved and signed by issuer. Submit to Horizon.
-    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. Submit to Horizon once signed.
-    3. *Pending?* The issuer will need to asynchronously approve this transaction. Wallet should send the same transaction to the approval service after a specified timeout (Return to 3).
+    1. *Success?* Transaction has been approved and signed by the issuer.
+    2. *Revised?* Transaction has been revised to be made compliant, and signed by the issuer. Wallet will show the changes to the user and ask them to sign the new transaction. **It is important to understand that an approval service could respond with a different transaction.**
+    3. *Pending?* The issuer could not determine whether to approve this transaction at the moment. Wallet can re-send the same transaction to the approval server later (Return to 3).
     4. *Action Required?* Transaction requires a user action to be completed. Wallet will present the attached action url as a clickable link, along with the attached message and an option to resubmit once the action has been taken.
-    5. *Rejected?* Wallet should display given error message to the user.
+    5. *Rejected?* Wallet should display the associated error message to the user.
 
-## Stellar.toml
-Issuers will advertise the existence of an Approval Service through their stellar.toml file. This is done in the [[CURRENCIES]] section as different assets can have different requirements.
+## Authorization Flags
+
+Regulated asset issuers must have both `Authorization Required` and `Authorization Revocable` flags set on their account. This allows the issuer to grant and revoke authorization to transact the asset at will.
+
+## SEP-1 stellar.toml
+
+Issuers advertise the existence of an Approval Service through their [SEP-1 stellar.toml] file. This is done in the `[[CURRENCIES]]` section as different assets can have different requirements.
 
 ### Fields:
 
+These fields are listed in the `[[CURRENCIES]]` section:
+
 - `regulated` is a boolean indicating whether or not this is a regulated asset. If missing, `false` is assumed.
-- `approval_server` is the url of an approval service that signs validated transactions.
+- `approval_server` is the URL of an approval service that signs validated transactions.
 - `approval_criteria` is a human readable string that explains the issuer's requirements for approving transactions.
 
 ### Example
@@ -62,106 +72,184 @@ approval_criteria="The goat approval server will ensure that transactions are co
 ```
 
 ## Approval Server
-The transaction approval server receives a signed transaction, checks for compliance and signs if possible.
 
-### Possible results
-- Success: Transaction was found compliant and signed by service.
-- Revised: Transaction was modified to be compliant and signed by service. It should be re-signed by the client.
-- Pending: The issuer will asynchronously validate the transaction and respond later.
-- Action Required: The user must complete an action in order to have the transaction approved.
-- Rejected: Transaction was rejected.
+Approval server is a single endpoint that receives a signed transaction, checks for compliance, and signs it on success.
 
-### Request
+The specification of an approval server is defined as follows:
 
-Transaction approval requests are executed by submitting an `HTTP POST` to `approval_server` with `Content-Type=application/x-www-form-urlencoded` and a single `tx` parameter. `tx` value is a base64 encoded Transaction Envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed if possible.
+### Content Type
 
-### Responses
+Approval server accepts requests in the `Content-Type`:
 
-HTTP responses have an `application/json` encoded body. All responses will contain, at least, a top level `status` parameter that indicates the type of the result.
+- `application/x-www-form-urlencoded`
 
+Approval server responds with the `Content-Type`:
 
-#### Success Response
+- `application/json`
 
-A Successful response will have a `200` HTTP status code and `success` as the `status` value. This response means that the transaction was found compliant and signed.
+### POST Endpoint
 
-Parameters:
+#### Request
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"success"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction will have both the original signature(s) from the request, as well as an additional issuer signature.
-message|string|A human readable string containing information to pass on to the user (optional).
+This endpoint accepts HTTP POST requests containing a single `tx` parameter.
 
-#### Revised Response
+Name | Type | Description
+-----|------|------------
+`tx` | string | A base64 encoded transaction envelope XDR signed by the user. This is the transaction that will be tested for compliance and signed on success.
 
-A Revised response will have a `200` HTTP status code and `revised` as the `status` value. It means that the transaction was revised to be made compliant. The user should examine and resign the transaction.
+###### Example (Form)
 
-Parameters:
+```
+tx=AAAAAHAHhQtYBh5F2zA6...
+```
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"revised"`
-tx|string|Transaction Envelope XDR, Base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
-message|string|A human readable string explaining the modifications made to the transaction to make it compliant.
+#### Responses
 
-#### Pending Response
+All responses will contain a top level `status` parameter that indicates the type of the result.
 
-A Pending response will have a `200` HTTP status code and `pending` as the `status` value. It means that the issuer needs to asynchronously validate the transaction. The user should resubmit the transaction after a given timeout.
+##### Success
+
+This response means that the transaction was found compliant and signed without being revised.
+
+A `success` response will have a `200` HTTP status code and `success` as the `status` value.
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"pending"`
-timeout|integer|Number of milliseconds to wait before submitting the same transaction again.
-message|string|A human readable string containing information to pass on to the user (optional).
+Name | Type | Description
+-----|------|------------
+`status` | string | `"success"`
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction will have both the original signature(s) from the request as well as one or multiple additional signatures from the issuer.
+`message` | string | (optional) A human readable string containing information to pass on to the user.
 
-#### Action Required Response
+###### Example
 
-An Action Required response will have a `200` HTTP status code and `action_required` as the `status` value. It means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+```json
+{
+  "status": "success",
+  "tx": "AAAAAHAHhQtYBh5F2zA6..."
+}
+```
+
+##### Revised
+
+This response means that the transaction was revised to be made compliant.
+
+A `revised` response will have a `200` HTTP status code and `revised` as the `status` value.
+
+It is important for the user to examine the revised transaction before re-signing it. More specifically, the user should make sure that the revised transaction does not contain any additional operations whose source account matches the source account of the original operation(s).
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"action_required"`
-message|string|A human readable string containing information regarding the action required.
-action_url|string|A URL that allows the user to complete the actions required to have the transaction approved.
+Name | Type | Description
+-----|------|------------
+`status` | string | `"revised"`
+`tx` | string | Transaction envelope XDR, base64 encoded. This transaction is a revised compliant version of the original request transation, signed by the issuer.
+`message` | string | A human readable string explaining the modifications made to the transaction to make it compliant.
 
-#### Rejected Response
+###### Example
 
-A Rejected response will have a `400` HTTP status code and `rejected` as the `status` value. It means that the transaction is not compliant and could not be revised to be made compliant.
+```json
+{
+  "status": "revised",
+  "tx": "AAAAAHAHhQtYBh5F2zA6...",
+  "message": "Authorization and deauthorization operations were added."
+}
+```
+
+##### Pending
+
+This response means that the issuer could not determine whether to approve the transaction at the time of receiving it. Wallet can re-submit the same transaction at a later point in time.
+
+A `pending` response will have a `200` HTTP status code and `pending` as the `status` value.
 
 Parameters:
 
-Name | Data Type | Description
------|-----------|------------
-status|string|`"rejected"`
-error|string|A human readable string explaining why the transaction is not compliant and could not be made compliant.
+Name | Type | Description
+-----|------|------------
+`status` | string | `"pending"`
+`timeout` | integer | Number of milliseconds to wait before submitting the same transaction again.
+`message` | string | (optional) A human readable string containing information to pass on to the user.
+
+###### Example
+
+```json
+{
+  "status": "pending",
+  "message": "Futher verifications are required due to..."
+}
+```
+
+##### Action Required
+
+This reponse means that the user must complete an action before this transaction can be approved. The approval service will provide a URL that facilitates the action. Upon completion, the user will resubmit the transaction.
+
+An `action_required` response will have a `200` HTTP status code and `action_required` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"action_required"`
+`message` | string | A human readable string containing information regarding the action required.
+`action_url` | string | A URL that allows the user to complete the actions required to have the transaction approved.
+
+###### Example
+
+```json
+{
+  "status": "action_required",
+  "message": "Please sign the terms of service via the provided URL.",
+  "action_url": "https://..."
+}
+```
+
+##### Rejected
+
+This response means that the transaction is not compliant and could not be revised to be made compliant.
+
+A `rejected` response will have a `400` HTTP status code and `rejected` as the `status` value.
+
+Parameters:
+
+Name | Type | Description
+-----|------|------------
+`status` | string | `"rejected"`
+`error` | string | A human readable string explaining why the transaction is not compliant and could not be made compliant.
+
+###### Example
+
+```json
+{
+  "status": "rejected",
+  "message": "The destination account is blocked."
+}
+```
 
 ### Best practices
 
 - If a transaction was revised, ALWAYS explain the changes that were made to a transaction through the `message` parameter.
+- Wallet should inspect revised transactions and alert the user if any of the original operations are changed.
 - Core operations shouldn't be modified as that can be confusing and misleading. For example, if the user wishes to put an offer for 1000 GOATS but due to velocity limits they can only put an offer for 500 GOATS, it is better to error with a message than to change the amount.
 - Adding an upper timebound to a transaction can help the issuer ensure that their view of the world does not get out of sync.
-- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving goats, will also send 0.1 GOAT to Boris’ account.
-- Once a transaction has been signed, the issuer should mark it as pending and take it into account, as long as it hasn’t been timed out, so that they can have a accurate view of the world.
+- Issuers can enforce additional fees by adding additional operations. For example, any transaction involving GOATs, will also send 0.1 GOAT to the issuer's account.
 
 ## Account Setup
 
 Implementing Regulated Assets requires the participating accounts to be “managed” by the issuer. This is achieved by having the issuer be a co-signer on the account, such that a medium threshold operation cannot be submitted without the issuer’s approval.
-
-In the future, this requirement can be replaced by introducing protocol level [CoSigned assets](https://github.com/stellar/stellar-protocol/issues/146).
 
 ## Discussion
 
 ### Should my asset be a regulated asset?
 
 Ideally, no. Implementing Regulated Assets should only be used when absolutely necessary, such as for regulatory reasons. It comes with a substantial operational overhead, added complexity, and burden for users. Issuers should only go down this route if it is absolutely required.
-Alternatively, some other available options are to utilize [SEP006](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md) in order to perform KYC on deposit and withdraw, and/or use [AUTHORIZATION_REQUIRED](https://www.stellar.org/developers/guides/issuing-assets.html#requiring-or-revoking-authorization) which allows issuers to authorize specific accounts to hold their issued assets.
 
 ### Why doesn’t the approval service submit transactions to the network?
 
 - Separation of concerns between signing transactions and submitting them.
 - Transactions might require more signatures from further regulated asset issuers.
+- Wallets can handle the failure from transaction submission based on the type of errors and reconstruct the transaction.
+- Scaling concerns as having the approval server submit transactions would require more infrastructure.
 
+[SEP-1 stellar.toml]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0001.md
+[authorization flags]: #authorization-flags
+[Approval Server]: #approval-server

--- a/ecosystem/sep-0009.md
+++ b/ecosystem/sep-0009.md
@@ -6,8 +6,8 @@ Title: Standard KYC / AML fields
 Author: stellar.org
 Status: Active
 Created: 2018-07-27
-Updated: 2020-04-03
-Version 1.2.0
+Updated: 2020-12-22
+Version 1.3.0
 ```
 
 ## Simple Summary
@@ -50,6 +50,7 @@ Name | Type | Description
 `bank_account_number` | string | Number identifying bank account
 `bank_number` | string | Number identifying bank in national banking system (routing number in US)
 `bank_phone_number` | string | Phone number with country code for bank
+`bank_branch_number` | string | Number identifying bank branch
 `tax_id` | string | Tax identifier of user in their country (social security number in US)
 `tax_id_name` | string | Name of the tax ID (`SSN` or `ITIN` in the US)
 `occupation` | number | Occupation ISCO code

--- a/ecosystem/sep-0010.md
+++ b/ecosystem/sep-0010.md
@@ -6,8 +6,8 @@ Title: Stellar Web Authentication
 Author: Sergey Nebolsin <@nebolsin>, Tom Quisel <tom.quisel@gmail.com>, Leigh McCulloch <@leighmcculloch>, Jake Urban <jake@stellar.org>
 Status: Active
 Created: 2018-07-31
-Updated: 2020-12-14
-Version 3.0.1
+Updated: 2021-01-11
+Version 3.1.0
 ```
 
 ## Simple Summary
@@ -19,8 +19,8 @@ This SEP defines the standard way for clients such as wallets or exchanges to cr
 This protocol is a variation of mutual challenge-response, which uses Stellar transactions to encode challenges and responses.
 
 It involves three components:
-- A domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `WEB_AUTH_ENDPOINT` and `SIGNING_KEY`, referred to as the home domain.
-- An endpoint providing the GET and POST operations discussed in this document.
+- A domain hosting a [SEP-1 stellar.toml](sep-0001.md) containing a `WEB_AUTH_ENDPOINT` (URL) and `SIGNING_KEY` (`G...`), referred to as the home domain.
+- An endpoint providing the GET and POST operations discussed in this document. The endpoint may be hosted on the home domain, a sub-domain of the home domain, or any other domain. The domain where the endpoint is hosted is referred to as the web auth domain. 
 - A client who will authenticate using a Stellar account.
 
 The discovery flow is as follows:
@@ -36,6 +36,10 @@ The authentication flow is as follows:
    1. Source account set to the user's account.
    1. Key set to `<home domain> auth` where the home domain is the home domain from the discovery flow.
    1. Value set to a nonce value.
+1. The client verifies that if the transaction has a Manage Data operation with key `web_auth_domain` that it has:
+   1. Source account set to the server's account.
+   1. Key set to `web_auth_domain`.
+   1. Value set to the domain name of the SEP-10 server from which the client requested the challenge.
 1. The client verifies that if the transaction has other operations they are Manage Data operations that all have their source accounts set to the the server's account.
 1. The client signs the transaction using the secret key(s) of signers for the user's Stellar account
 1. The client submits the signed challenge back to the server using [`token`](#token) endpoint
@@ -115,7 +119,10 @@ On success the endpoint must return `200 OK` HTTP status code and a JSON object 
     * `manage_data(source: client_account, key: '<home domain> auth', value: random_nonce())`
       * The value of key is the home domain the client is authenticating with, followed by `auth`. It can be at most 64 characters.
       * The value must be 64 bytes long. It contains a 48 byte cryptographic-quality random string encoded using base64 (for a total of 64 bytes after encoding).
-    * zero or more `manage_data(source: server_account, ...)` reserved for future use
+    * subsequent operations, order unimportant:
+      * `manage_data(source: server_account, key: 'web_auth_domain', value: web_auth_domain)`
+        * The value is the web auth domain, the domain hosting the web auth endpoint and that the client connected to when requesting the challenge transaction. It can be at most 64 characters.
+      * zero or more `manage_data(source: server_account, ...)` reserved for future use
   * signature by the service's stellar.toml `SIGNING_KEY`
 * `network_passphrase`: (optional but recommended) Stellar network passphrase used by the server. This allows the client to verify that it's using the correct passphrase when signing and is useful for identifying when a client or server have been configured incorrectly.
 

--- a/ecosystem/sep-0012.md
+++ b/ecosystem/sep-0012.md
@@ -107,8 +107,8 @@ Name | Type | Description
 -----|------|------------
 `id` | string | (optional) ID of the customer, if the customer has already been created via a `PUT /customer` request.
 `status` | string | Status of the customers KYC process.
-`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type
-`message` | string | (optional) Human readable reason for rejection
+`fields` | object | (optional) An object containing the fields still needed to finish KYC Process for the given KYC type.
+`message` | string | (optional) Human readable message describing the current state of customer's KYC process.
 
 ```js
 // The case when a customer has been successfully KYC'd and approved
@@ -156,6 +156,15 @@ Name | Type | Description
          "type": "string"
       }
    }
+}
+```
+
+```js
+// The case when the Anchor is processing KYC information  
+{
+    "id": "46116754-695e-43f6-84c4-8c05e50a7b12",
+    "status": "PROCESSING",
+    "message": "Photo ID requires manual review. This process typically takes 1-2 business days."
 }
 ```
 

--- a/ecosystem/sep-0024.md
+++ b/ecosystem/sep-0024.md
@@ -186,22 +186,23 @@ Responses are detailed in the [Deposit and Withdraw shared responses](#deposit-a
 ##### Special Cases
 ###### Stellar account does not exist
 
-If the given Stellar `account` does not exist, on receipt of the deposit, the anchor should use `create_account` to create the account with at least enough XLM for the minimum reserve and a trust line (2.01 XLM is recommended). The anchor should take some of the asset that is sent in to pay for the XLM. The anchor should not list this minimal funding as a fee because the user still receives the value of the XLM in their account. The anchor should detect if the account has been created before returning deposit information, and adjust the `min_amount` in the response to be at least the amount needed to create the account.
+If the given Stellar `account` does not exist on receipt of the deposit funds, the anchor should use the `CreateAccount` operation to create the account with at least enough XLM for the minimum reserve and a trust line to the requested asset (2.01 XLM is recommended). The anchor can add this minimal funding amount to the service fee, but this requires calculating the worth of the minimum funding amount in units of the requested asset.
 
-Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the remaining asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the remaining asset tokens to the account in Stellar to complete the deposit.
+Since the anchor doesn't have the user account's secret key, the user must create a trust line to the anchor's asset before the anchor can send the requested asset tokens to the user's account. The anchor should listen for the user to establish this trust line. Once the trust line is there, the anchor should send the requested asset tokens to the account on Stellar to complete the deposit.
 
-If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error. The response body should be a JSON object containing an `error` field that explains why the request failed.
+If the anchor does not support creating new accounts for users and `account` doesn't exist yet, the anchor should return a `400 Bad Request` error in the [deposit](#deposit) response. The response body should be a JSON object containing an `error` field that explains why the request failed.
 
 ###### Stellar account doesn't trust asset
 
-The deposit flow can only be fulfilled if the Stellar `Account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `Account` has a trust line for the given asset. If it doesn't:
+The deposit flow can only be fulfilled if the Stellar `account` has established a trust line for the given asset. To ensure this is accomplished, when initiating the deposit flow, `Wallet` should check if the `account` has a trust line for the given asset. If it doesn't:
 
-1. `Wallet` checks if `Account` has enough XLM to create a trust line. If it does, skip to step `4`.
-2. If `Account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `Account`, waiting for it to have enough XLM for a trust line.
-3. When asked for a deposit, `Anchor` detects if `Account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` then starts listening for trust line creations for that `Account`.
-4. `Wallet` detects the arrival of XLM in the `Account`, and establishes a trust line.
-5. `Anchor` detects the trust line creation in the `Account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
-6. `Anchor` proceeds with the deposit flow.
+1. `Wallet` checks if `account` has enough XLM to create a trust line. If it does, skip to step `4`.
+2. If `account` doesn't have enough XLM, `Wallet` starts listening for transactions to the given `account`, waiting for it to have enough XLM for a trust line.
+3. When asked for a deposit, `Anchor` detects if `account` has enough XLM to create a trust line. If it doesn't, `Anchor` sends the needed amount of XLM to the `Account` for creating a trust line. `Anchor` may charge a service fee to cover the cost of the XLM, but this must be communicated to the user.
+4. `Anchor` then starts listening for trust line creations for that `account`.
+5. `Wallet` detects the arrival of XLM in the `account`, and establishes a trust line.
+6. `Anchor` detects the trust line creation in the `account`. If the asset is `AUTH_REQUIRED`, `Anchor` approves the new trust line.
+7. `Anchor` proceeds with the deposit flow.
 
 ## Withdraw
 

--- a/ecosystem/sep-0030.md
+++ b/ecosystem/sep-0030.md
@@ -9,7 +9,7 @@ Status: Draft
 Discussion: https://groups.google.com/forum/#!topic/stellar-dev/SFr2dHBZlsY
 Created: 2019-12-20
 Updated: 2020-11-17
-Version: 0.7.0
+Version: 0.8.0
 ```
 
 ## Summary
@@ -156,8 +156,7 @@ prove they meet the high threshold on the account.
 
 ### Content Type
 
-All endpoints accept in requests the following `Content-Type`s:
-- `application/x-www-form-urlencoded`
+All endpoints accept in requests the following `Content-Type`:
 - `application/json`
 
 All endpoints respond with content type:
@@ -225,8 +224,6 @@ Type | Description
 
 ##### Example (With One Identity)
 
-###### JSON
-
 ```json
 {
   "identities": [
@@ -242,15 +239,7 @@ Type | Description
 }
 ```
 
-###### Form
-
-```
-identities.0.role=owner&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001
-```
-
 ##### Example (With Multiple Roles)
-
-###### JSON
 
 ```json
 {
@@ -273,12 +262,6 @@ identities.0.role=owner&identities.0.auth_methods.account=GDUA...&identities.0.a
     },
   ]
 }
-```
-
-###### Form
-
-```
-identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 #### Common Response Fields
@@ -349,7 +332,7 @@ declaring should be allowed to gain control of the account.
 
 See [Common Fields].
 
-###### Example (JSON)
+###### Example
 
 ```json
 {
@@ -372,12 +355,6 @@ See [Common Fields].
     },
   ]
 }
-```
-
-###### Example (Form)
-
-```
-identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -431,7 +408,7 @@ request does not include it, it is removed.
 
 See [Common Fields].
 
-###### Example (JSON)
+###### Example
 
 ```json
 {
@@ -454,12 +431,6 @@ See [Common Fields].
     },
   ]
 }
-```
-
-###### Example (Form)
-
-```
-identities.0.role=sender&identities.0.auth_methods.account=GDUA...&identities.0.auth_methods.email=person1%40example.com&identities.0.auth_methods.phone_number=%2B10000000001&identities.1.role=receiver&identities.1.auth_methods.account=GBEA...&identities.1.auth_methods.email=person2%40example.com&identities.1.auth_methods.phone_number=%2B10000000002
 ```
 
 ##### Response
@@ -531,18 +502,12 @@ Name | Type | Description
 -----|------|------------
 `transaction` | string | A XDR base64 encoded Stellar transaction.
 
-###### Example (JSON)
+###### Example
 
 ```json
 {
   "transaction": "AAAAAHAHhQtYBh5F2zA6...",
 }
-```
-
-###### Example (Form)
-
-```
-transaction=AAAAAHAHhQtYBh5F2zA6...
 ```
 
 ##### Response


### PR DESCRIPTION
### What
Merge stellar-protocol `master` into stellar/stellar-protocol#758 and update the action_required action_url POST case to require a 200 status code instead of a 303, and to return a body containing a `next_url` instead of relying on the `Location` header.

### Why
There have been changes on master that reformatted SEP-8 (stellar/stellar-protocol#813) that caused conflicts. Most of the changes in this PR are resolving those conflicts and updating the PR to contain `master`.  The changes after the merge commit are the tangible changes that update the status code to 200 and the body to contain `next_url`. Those changes are required to support modern web applications that wish to make the POST request in the background since browsers do not support intercepting the 303 status code response.