### PR TITLE
SEP-0008: Copy update and add terminal state for action_url POST endpoint

### DIFF
--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -241,11 +241,11 @@ Name | Type | Description
 ```
 
 ###### Action URL
-If the `action_method` is provided the client uses the type of request indicated when sending a request to the `action_url`. If `action_fields` are to be provided and the fields contain sensitive or personal information the `POST` case is preferred to ensure sensitive information is not transmitted in the URL.
+If the `action_method` is provided, the client uses the type of request indicated when sending a request to the `action_url`. If `action_fields` are to be provided and the fields contain sensitive or personal information, the `POST` case is preferred to ensure sensitive information is not transmitted in the URL.
 
-- In the case that `action_method` is `GET` any fields requested may be passed as query parameters in the `action_url`.
+- In the case that `action_method` is `GET`, any fields requested may be passed as query parameters in the `action_url`.
 
-- In the case that `action_method` is `POST` any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json` and a body containing the next URL that the user should be taken to.
+- In the case that `action_method` is `POST`, any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json` and a body containing the next URL that the user should be taken to.
 
    The next URL in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser can redirect the user to the next URL and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the next URL.
 

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -245,9 +245,9 @@ If the `action_method` is provided, the client uses the type of request indicate
 
 - In the case that `action_method` is `GET`, any fields requested may be passed as query parameters in the `action_url`.
 
-- In the case that `action_method` is `POST`, any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json` and a body containing the next URL that the user should be taken to.
+- In the case that `action_method` is `POST`, any fields requested may be passed as JSON in the request body, using content type `application/json`. The server should respond to the `POST` with a HTTP response with status code `200`, content-type `application/json`. The body should contain either an acknowledgement that the `POST` was sufficient and no further action is required, or the next URL that the user should be taken to if action is still required.
 
-   The next URL in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser can redirect the user to the next URL and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the next URL.
+   The next URL in the POST case is necessary to support products that are websites and products that are mobile applications. Products that run entirely in the browser can redirect the user to the next URL and the redirect prevents odd user experiences where a user refreshes a page and is prompted to re-post the data. Products that are mobile applications cannot open a system browser with a POST request. They can make the POST request internally, extract the redirect in the response, and open a system browser with the next URL. Separating the next URL also makes it possible for the server to indicate that the fields provided in the POST request were sufficient and no further user interaction is required.
 
    Request Parameters:
 
@@ -261,16 +261,32 @@ If the `action_method` is provided, the client uses the type of request indicate
    }
    ```
 
-   Response Parameters:
+   Response Parameters when no further action required:
 
    Name | Type | Description
    -----|------|------------
+   `status` | string | `no_further_action_required`.
+
+   Response Example:
+
+   ```json
+   {
+     "status": "no_further_action_required"
+   }
+   ```
+
+   Response Parameters when further action required:
+
+   Name | Type | Description
+   -----|------|------------
+   `status` | string | `follow_next_url`.
    `next_url` | string | A URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
 
    Response Example:
 
    ```json
    {
+     "status": "follow_next_url",
      "next_url": "https://..."
    }
    ```

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -265,13 +265,13 @@ If the `action_method` is provided, the client uses the type of request indicate
 
    Name | Type | Description
    -----|------|------------
-   `status` | string | `no_further_action_required`.
+   `result` | string | `no_further_action_required`.
 
    Response Example:
 
    ```json
    {
-     "status": "no_further_action_required"
+     "result": "no_further_action_required"
    }
    ```
 
@@ -279,14 +279,14 @@ If the `action_method` is provided, the client uses the type of request indicate
 
    Name | Type | Description
    -----|------|------------
-   `status` | string | `follow_next_url`.
+   `result` | string | `follow_next_url`.
    `next_url` | string | A URL where the user can complete the required actions with all the parameters included in the original POST pre-filled or already accepted.
 
    Response Example:
 
    ```json
    {
-     "status": "follow_next_url",
+     "result": "follow_next_url",
      "next_url": "https://..."
    }
    ```

--- a/ecosystem/sep-0008.md
+++ b/ecosystem/sep-0008.md
@@ -225,8 +225,8 @@ Name | Type | Description
 `status` | string | `"action_required"`
 `message` | string | A human readable string containing information regarding the action required.
 `action_url` | string | A URL that allows the user to complete the actions required to have the transaction approved.
-`action_method` | string | (Optional) `GET` or `POST`, indicating the type of request that should be made to the `action_url`. If not provided, `GET` is assumed.
-`action_fields` | string[] | (Optional) An array of additional fields defined by [SEP-9 Standard KYC / AML fields] that the client may optionally provide to the approval service when sending the request to the `action_url`.
+`action_method` | string | (optional) `GET` or `POST`, indicating the type of request that should be made to the `action_url`. If not provided, `GET` is assumed.
+`action_fields` | string[] | (optional) An array of additional fields defined by [SEP-9 Standard KYC / AML fields] that the client may optionally provide to the approval service when sending the request to the `action_url`.
 
 ###### Example
 


### PR DESCRIPTION
### What
1. Some minor copy updates:
   - Optional => optional
   - Add commas in places that makes the sentences easier to read
2. Add an early exit state for the action_url POST where the client knows it doesn't need to follow a next url.

### Why
The minor copy updates are feedback from @howardtw on stellar/stellar-protocol#758.

The terminal states was a suggestion from @accordeiro. The idea being that if we support providing some data upfront in the POST like email, etc, it is feasible that an `action_url` may be able to process and validate that data instantly, and if they can do that there's no really any need to display a `next_url` to the user. There's probably other ways to improve this, but I'd like to cap it here with just offering a next url or not to keep it simple. Most other use cases I think can be addressed by saying no further action is required, and returning to the main SEP-8 API.

### Merging
This change is intended for inclusion in stellar/stellar-protocol#758.